### PR TITLE
feat: add session guard action

### DIFF
--- a/foxbot/actions/index.ts
+++ b/foxbot/actions/index.ts
@@ -7,4 +7,5 @@ export * from "./navigate";
 export * from "./no-op";
 export * from "./sequence";
 export * from "./session";
+export * from "./session-guard";
 export * from "./when";

--- a/foxbot/actions/session-guard.ts
+++ b/foxbot/actions/session-guard.ts
@@ -1,0 +1,37 @@
+import type { Action } from "../core/action";
+import type { Session } from "../playwright/session";
+
+/**
+ * Wraps an action and ensures the session is closed after the action runs.
+ *
+ * @example
+ * ```typescript
+ * const guard = new SessionGuard(action, session);
+ * await guard.perform(); // session is closed afterward
+ * ```
+ */
+export class SessionGuard implements Action {
+  /**
+   * Creates a new session guard.
+   *
+   * @param target Action to execute
+   * @param session Session to close after execution
+   */
+  constructor(
+    private readonly target: Action,
+    private readonly session: Session
+  ) {}
+
+  /**
+   * Executes the target action and closes the session afterward.
+   *
+   * @returns Promise that resolves when the action has run and the session is closed
+   */
+  async perform(): Promise<void> {
+    try {
+      await this.target.perform();
+    } finally {
+      await this.session.close();
+    }
+  }
+}

--- a/foxbot/actions/session.ts
+++ b/foxbot/actions/session.ts
@@ -29,31 +29,3 @@ export class OpenSession implements Action {
     await this.session.open();
   }
 }
-
-/**
- * Action primitive that closes a browser session.
- * Calls the close() method on the provided session to clean up browser resources.
- *
- * @example
- * ```typescript
- * const closeAction = new CloseSession(session);
- * await closeAction.perform(); // session is now closed
- * ```
- */
-export class CloseSession implements Action {
-  /**
-   * Creates a new close session action.
-   *
-   * @param session Session to close
-   */
-  constructor(private readonly session: Session) {}
-
-  /**
-   * Closes the browser session.
-   *
-   * @returns Promise that resolves when session is closed
-   */
-  async perform(): Promise<void> {
-    await this.session.close();
-  }
-}

--- a/tests/unit/foxbot/actions/action-primitives.test.ts
+++ b/tests/unit/foxbot/actions/action-primitives.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { CloseSession, Fork, NoOp, OpenSession, Sequence } from "../../../../foxbot/actions";
+import { Fork, NoOp, Sequence } from "../../../../foxbot/actions";
 import type { Action } from "../../../../foxbot/core";
 import { BooleanLiteral } from "../../../../foxbot/core";
-
-import { FakeSession } from "../../../fakes/fake-session";
 
 describe("Action primitives", () => {
   it("should execute sequence actions in order", async () => {
@@ -65,18 +63,5 @@ describe("Action primitives", () => {
 
     expect(thenExecuted).toBe(false);
     expect(elseExecuted).toBe(true);
-  });
-
-  it("should open and close sessions", async () => {
-    const session = new FakeSession();
-
-    const openAction = new OpenSession(session);
-    const closeAction = new CloseSession(session);
-
-    await openAction.perform();
-    expect(session.isOpen).toBe(true);
-
-    await closeAction.perform();
-    expect(session.isOpen).toBe(false);
   });
 });

--- a/tests/unit/foxbot/actions/actions.test.ts
+++ b/tests/unit/foxbot/actions/actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { CloseSession, Fork, NoOp, OpenSession, Sequence, When } from "../../../../foxbot/actions";
+import { Fork, NoOp, OpenSession, Sequence, When } from "../../../../foxbot/actions";
 import type { Action, Query } from "../../../../foxbot/core";
 import { BooleanLiteral } from "../../../../foxbot/core";
 
@@ -170,15 +170,12 @@ describe("actions", () => {
   });
 
   describe("Session actions", () => {
-    it("OpenSession opens session and CloseSession closes session", async () => {
-      expect.assertions(2);
+    it("OpenSession opens session", async () => {
+      expect.assertions(1);
       const session = new FakeSession();
       const openAction = new OpenSession(session);
-      const closeAction = new CloseSession(session);
       await openAction.perform();
       expect(session.isOpen, "Session was not opened").toBe(true);
-      await closeAction.perform();
-      expect(session.isOpen, "Session was not closed").toBe(false);
     });
   });
 });

--- a/tests/unit/foxbot/actions/session-guard.test.ts
+++ b/tests/unit/foxbot/actions/session-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { SessionGuard } from "../../../../foxbot/actions";
+import type { Action } from "../../../../foxbot/core";
+import { FakeSession } from "../../../fakes/fake-session";
+
+/**
+ * Test action implementation that succeeds without side effects.
+ */
+class SuccessfulAction implements Action {
+  async perform(): Promise<void> {}
+}
+
+/**
+ * Test action implementation that throws an error when performed.
+ */
+class FailingAction implements Action {
+  async perform(): Promise<void> {
+    throw new Error("boom");
+  }
+}
+
+describe("SessionGuard", () => {
+  it("closes session after target action completes", async () => {
+    expect.assertions(1);
+    const session = new FakeSession();
+    await session.open();
+    const guard = new SessionGuard(new SuccessfulAction(), session);
+    await guard.perform();
+    expect(session.isOpen, "SessionGuard did not close the session").toBe(false);
+  });
+
+  it("closes session even when target action throws", async () => {
+    expect.assertions(2);
+    const session = new FakeSession();
+    await session.open();
+    const guard = new SessionGuard(new FailingAction(), session);
+    await expect(guard.perform()).rejects.toThrow("boom");
+    expect(session.isOpen, "SessionGuard did not close the session after error").toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `SessionGuard` action to ensure browser sessions close after target actions
- export `SessionGuard` from actions index
- remove obsolete `CloseSession` action and related tests

## Testing
- `npm test` *(fails: browserType.launch: Host system is missing dependencies to run browsers)*
- `npx vitest run tests/unit/foxbot`


------
https://chatgpt.com/codex/tasks/task_e_68ac921753f4832ea4fd50ca0c415e6b