### PR TITLE
docs: align JSDoc with steering guidelines

### DIFF
--- a/foxbot/browser/chromium.ts
+++ b/foxbot/browser/chromium.ts
@@ -3,12 +3,31 @@ import type { Browser } from "playwright";
 
 import { Query } from "../core";
 
+/**
+ * A query that launches a Chromium browser instance.
+ *
+ * @example
+ * ```typescript
+ * const browser = await new Chromium(headless, args).value();
+ * ```
+ */
 export class Chromium implements Query<Browser> {
+  /**
+   * Creates a new Chromium browser query.
+   *
+   * @param headless Query that determines if the browser runs headless
+   * @param args Query that provides comma-separated launch arguments
+   */
   constructor(
     private readonly headless: Query<boolean>,
     private readonly args: Query<string>
   ) {}
 
+  /**
+   * Launches the browser with the provided configuration.
+   *
+   * @returns Promise that resolves to the launched browser
+   */
   async value(): Promise<Browser> {
     return chromium.launch({
       headless: await this.headless.value(),

--- a/foxbot/control/no-op.ts
+++ b/foxbot/control/no-op.ts
@@ -17,7 +17,5 @@ export class NoOp implements Action {
    *
    * @returns Promise that resolves immediately
    */
-  async perform(): Promise<void> {
-    // Intentionally does nothing
-  }
+  async perform(): Promise<void> {}
 }

--- a/foxbot/session/optimized-session.ts
+++ b/foxbot/session/optimized-session.ts
@@ -2,11 +2,27 @@ import type { BrowserContext, Route } from "playwright";
 import type { Session } from "./session";
 
 /**
- * Decorator to set up resource blocking for a session.
+ * Decorator that blocks unnecessary network requests for a session.
+ *
+ * @example
+ * ```typescript
+ * const optimized = new OptimizedSession(session);
+ * const context = await optimized.profile();
+ * ```
  */
 export class OptimizedSession implements Session {
+  /**
+   * Creates a new optimized session.
+   *
+   * @param session Base session to decorate
+   */
   constructor(private readonly session: Session) {}
 
+  /**
+   * Provides a browser context with resource blocking enabled.
+   *
+   * @returns Promise that resolves to the optimized browser context
+   */
   async profile(): Promise<BrowserContext> {
     const context = await this.session.profile();
     await context.route("**/*", async (route: Route) => {
@@ -23,7 +39,11 @@ export class OptimizedSession implements Session {
   }
 
   /**
-   * Determines if a resource should be blocked based on type and URL patterns.
+   * Checks if a resource should be blocked.
+   *
+   * @param resourceType Resource type of the request
+   * @param url Request URL
+   * @returns True when the resource must be blocked
    */
   private isResourceBlocked(resourceType: string, url: string): boolean {
     const defaultBlockedTypes = ["image", "font", "media"];

--- a/foxbot/session/session-guard.ts
+++ b/foxbot/session/session-guard.ts
@@ -28,7 +28,6 @@ export class SessionGuard implements Action {
    * @returns Promise that resolves when the action has run and the session is closed
    */
   async perform(): Promise<void> {
-    // Acquire context first so we don't attempt to create it in an error state inside finally.
     const context = await this.session.profile();
     try {
       await this.target.perform();

--- a/foxbot/session/session.ts
+++ b/foxbot/session/session.ts
@@ -3,6 +3,12 @@ import type { BrowserContext } from "playwright";
 /**
  * Interface for managing a Playwright browser session lifecycle.
  * Provides explicit lifecycle management with open and close methods.
+ *
+ * @example
+ * ```typescript
+ * const session: Session = new DefaultSession(...);
+ * const context = await session.profile();
+ * ```
  */
 export interface Session {
   /**

--- a/reachly/browser/headless.ts
+++ b/reachly/browser/headless.ts
@@ -1,8 +1,25 @@
 import { Query } from "../../foxbot/core";
 
+/**
+ * A query that determines if the browser should run in headless mode.
+ *
+ * @example
+ * ```typescript
+ * const headless = new Headless();
+ * const enabled = await headless.value();
+ * ```
+ */
 export class Headless implements Query<boolean> {
+  /**
+   * Creates a headless mode query.
+   */
   constructor() {}
 
+  /**
+   * Indicates whether headless mode is enabled.
+   *
+   * @returns Promise that resolves to true when headless is enabled
+   */
   async value(): Promise<boolean> {
     return process.env["HEADLESS"] === "true";
   }

--- a/reachly/browser/stealth-args.ts
+++ b/reachly/browser/stealth-args.ts
@@ -1,8 +1,24 @@
 import { Query } from "../../foxbot/core";
 
+/**
+ * A query that returns Chromium launch arguments for stealth mode.
+ *
+ * @example
+ * ```typescript
+ * const args = await new StealthArgs().value();
+ * ```
+ */
 export class StealthArgs implements Query<string> {
+  /**
+   * Creates a stealth arguments query.
+   */
   constructor() {}
 
+  /**
+   * Provides comma-separated launch arguments.
+   *
+   * @returns Promise that resolves to the launch argument string
+   */
   async value(): Promise<string> {
     const defaultChromeArgs = [
       "--no-sandbox",


### PR DESCRIPTION
## Summary
- expand missing JSDoc on core browser and session utilities
- remove inline comments to satisfy steering rules
- document Reachly headless and stealth arguments helpers

## Testing
- `npm run lint`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a42d5970832e8aa5809b6f881984