### PR TITLE
feat: add root-based imports

### DIFF
--- a/examples/linkedin-example/linkedin-example.ts
+++ b/examples/linkedin-example/linkedin-example.ts
@@ -1,7 +1,7 @@
 import type { Browser } from "playwright";
-import { Query } from "../../foxbot/core";
-import { OptimizedSession } from "../../foxbot/session";
-import { TextLiteral } from "../../foxbot/value";
+import { Query } from "#foxbot/core";
+import { OptimizedSession } from "#foxbot/session";
+import { TextLiteral } from "#foxbot/value";
 import {
   AuthenticatedSession,
   DefaultSession,
@@ -11,7 +11,7 @@ import {
   JsonLocation,
   JsonViewport,
   StealthSession,
-} from "../../reachly/session";
+} from "#reachly/session";
 
 /**
  * Creates LinkedIn session using the decorator composition pattern based on a shared JSON string.

--- a/foxbot/browser/chromium.ts
+++ b/foxbot/browser/chromium.ts
@@ -1,7 +1,7 @@
 import { chromium } from "playwright";
 import type { Browser } from "playwright";
 
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that launches a Chromium browser instance.

--- a/foxbot/control/action_decorator.ts
+++ b/foxbot/control/action_decorator.ts
@@ -1,4 +1,4 @@
-import { Action } from "../core";
+import { Action } from "#foxbot/core";
 
 /**
  * Base decorator class that wraps an action and forwards perform calls.

--- a/foxbot/control/delay.ts
+++ b/foxbot/control/delay.ts
@@ -1,4 +1,4 @@
-import { Action, Query } from "../core";
+import { Action, Query } from "#foxbot/core";
 
 /**
  * An action that waits for a specified number of milliseconds.

--- a/foxbot/control/fork.ts
+++ b/foxbot/control/fork.ts
@@ -1,5 +1,5 @@
-import type { Action } from "../core/action";
-import type { Query } from "../core/query";
+import type { Action } from "#foxbot/core/action";
+import type { Query } from "#foxbot/core/query";
 
 /**
  * Fork action primitive that executes one of two actions based on a condition.

--- a/foxbot/control/lambda.ts
+++ b/foxbot/control/lambda.ts
@@ -1,4 +1,4 @@
-import type { Action } from "../core";
+import type { Action } from "#foxbot/core";
 
 /**
  * An action that executes a provided function when performed.

--- a/foxbot/control/no-op.ts
+++ b/foxbot/control/no-op.ts
@@ -1,4 +1,4 @@
-import type { Action } from "../core/action";
+import type { Action } from "#foxbot/core/action";
 
 /**
  * No-operation action primitive that does nothing when executed.

--- a/foxbot/control/sequence.ts
+++ b/foxbot/control/sequence.ts
@@ -1,4 +1,4 @@
-import { Action } from "../core";
+import { Action } from "#foxbot/core";
 
 /**
  * An action that executes multiple actions in sequence.

--- a/foxbot/control/when.ts
+++ b/foxbot/control/when.ts
@@ -1,4 +1,4 @@
-import { Action, Query } from "../core";
+import { Action, Query } from "#foxbot/core";
 
 /**
  * A conditional action that executes another action only if a predicate is true.

--- a/foxbot/element/click.ts
+++ b/foxbot/element/click.ts
@@ -1,6 +1,6 @@
 import type { Locator as PwLocator } from "playwright";
 
-import { Action, Query } from "../core";
+import { Action, Query } from "#foxbot/core";
 
 /**
  * An action that clicks on a web element.

--- a/foxbot/element/fill.ts
+++ b/foxbot/element/fill.ts
@@ -1,6 +1,6 @@
 import type { Locator as PwLocator } from "playwright";
 
-import { Action, Query } from "../core";
+import { Action, Query } from "#foxbot/core";
 
 /**
  * An action that fills a form element with text.

--- a/foxbot/element/locator.ts
+++ b/foxbot/element/locator.ts
@@ -1,6 +1,6 @@
 import type { Page, Locator as PwLocator } from "playwright";
 
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that locates elements on a page using a CSS selector.

--- a/foxbot/element/presence.ts
+++ b/foxbot/element/presence.ts
@@ -1,6 +1,6 @@
 import type { Locator as PwLocator } from "playwright";
 
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that checks whether an element is present on the page.

--- a/foxbot/element/text_of.ts
+++ b/foxbot/element/text_of.ts
@@ -1,6 +1,6 @@
 import type { Locator as PwLocator } from "playwright";
 
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that extracts the text content from a web element.

--- a/foxbot/page/location_of.ts
+++ b/foxbot/page/location_of.ts
@@ -1,6 +1,6 @@
 import type { Page } from "playwright";
 
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that retrieves the current URL of a page.

--- a/foxbot/page/navigate.ts
+++ b/foxbot/page/navigate.ts
@@ -1,6 +1,6 @@
 import type { Page } from "playwright";
 
-import { Action, Query } from "../core";
+import { Action, Query } from "#foxbot/core";
 
 /**
  * An action that navigates a browser page to a specified URL.

--- a/foxbot/page/page_of.ts
+++ b/foxbot/page/page_of.ts
@@ -1,7 +1,7 @@
 import type { Page } from "playwright";
 
-import { Query } from "../core";
-import type { Session } from "../session";
+import { Query } from "#foxbot/core";
+import type { Session } from "#foxbot/session";
 
 /**
  * A query that retrieves an existing page from a browser session.

--- a/foxbot/session/session-guard.ts
+++ b/foxbot/session/session-guard.ts
@@ -1,4 +1,4 @@
-import type { Action } from "../core/action";
+import type { Action } from "#foxbot/core/action";
 import type { Session } from "./session";
 
 /**

--- a/foxbot/value/base64.ts
+++ b/foxbot/value/base64.ts
@@ -1,4 +1,4 @@
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that decodes a base64-encoded string.

--- a/foxbot/value/contains.ts
+++ b/foxbot/value/contains.ts
@@ -1,4 +1,4 @@
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that checks if one string contains another.

--- a/foxbot/value/environment.ts
+++ b/foxbot/value/environment.ts
@@ -1,4 +1,4 @@
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that retrieves an environment variable value.

--- a/foxbot/value/environment_base64.ts
+++ b/foxbot/value/environment_base64.ts
@@ -1,4 +1,4 @@
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that retrieves a base64-encoded environment variable and decodes it.

--- a/foxbot/value/number_literal.ts
+++ b/foxbot/value/number_literal.ts
@@ -1,4 +1,4 @@
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that returns a number literal value.

--- a/foxbot/value/random_delay.ts
+++ b/foxbot/value/random_delay.ts
@@ -1,4 +1,4 @@
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that generates a random delay between specified minimum and maximum bounds.

--- a/foxbot/value/text_literal.ts
+++ b/foxbot/value/text_literal.ts
@@ -1,4 +1,4 @@
-import { Query } from "../core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that returns a string literal value.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,12 @@
     "typescript-eslint": "^8.40.0",
     "vitest": "^3.2.4"
   },
+  "imports": {
+    "#foxbot/*": "./foxbot/*",
+    "#reachly/*": "./reachly/*",
+    "#examples/*": "./examples/*",
+    "#tests/*": "./tests/*"
+  },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
       "prettier --write",

--- a/reachly/browser/headless.ts
+++ b/reachly/browser/headless.ts
@@ -1,4 +1,4 @@
-import { Query } from "../../foxbot/core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that determines if the browser should run in headless mode.

--- a/reachly/browser/stealth-args.ts
+++ b/reachly/browser/stealth-args.ts
@@ -1,4 +1,4 @@
-import { Query } from "../../foxbot/core";
+import { Query } from "#foxbot/core";
 
 /**
  * A query that returns Chromium launch arguments for stealth mode.

--- a/reachly/linkedin/login.ts
+++ b/reachly/linkedin/login.ts
@@ -1,8 +1,8 @@
-import { ActionDecorator, Delay, Sequence } from "../../foxbot/control";
-import { Click, Fill, Locator } from "../../foxbot/element";
-import { Navigate, PageOf } from "../../foxbot/page";
-import { Base64, Environment, NumberLiteral, RandomDelay, TextLiteral } from "../../foxbot/value";
-import type { Session } from "../../foxbot/session";
+import { ActionDecorator, Delay, Sequence } from "#foxbot/control";
+import { Click, Fill, Locator } from "#foxbot/element";
+import { Navigate, PageOf } from "#foxbot/page";
+import { Base64, Environment, NumberLiteral, RandomDelay, TextLiteral } from "#foxbot/value";
+import type { Session } from "#foxbot/session";
 
 /**
  * LinkedIn login workflow that authenticates using credentials from environment variables.

--- a/reachly/session/authenticated-session.ts
+++ b/reachly/session/authenticated-session.ts
@@ -1,5 +1,5 @@
 import { BrowserContext } from "playwright";
-import type { Session } from "../../foxbot/session";
+import type { Session } from "#foxbot/session";
 import { Host } from "./host";
 
 /**

--- a/reachly/session/default-session.ts
+++ b/reachly/session/default-session.ts
@@ -1,7 +1,7 @@
 import type { Browser, BrowserContext } from "playwright";
 
-import { Query } from "../../foxbot/core/query";
-import type { Session } from "../../foxbot/session";
+import { Query } from "#foxbot/core/query";
+import type { Session } from "#foxbot/session";
 import { Host } from "./host";
 import { Location } from "./location";
 import { Viewport } from "./viewport";

--- a/reachly/session/device.ts
+++ b/reachly/session/device.ts
@@ -1,4 +1,4 @@
-import type { Query } from "../../foxbot/core";
+import type { Query } from "#foxbot/core";
 
 /**
  * Device characteristics exposed to scripts.

--- a/reachly/session/graphics.ts
+++ b/reachly/session/graphics.ts
@@ -1,4 +1,4 @@
-import type { Query } from "../../foxbot/core";
+import type { Query } from "#foxbot/core";
 
 /**
  * Graphics adapter characteristics (WebGL).

--- a/reachly/session/host.ts
+++ b/reachly/session/host.ts
@@ -1,4 +1,4 @@
-import type { Query } from "../../foxbot/core";
+import type { Query } from "#foxbot/core";
 
 /**
  * Host environment information describing browser-identifying attributes.

--- a/reachly/session/location.ts
+++ b/reachly/session/location.ts
@@ -1,4 +1,4 @@
-import type { Query } from "../../foxbot/core";
+import type { Query } from "#foxbot/core";
 
 /**
  * Geolocation coordinates.

--- a/reachly/session/single-page.ts
+++ b/reachly/session/single-page.ts
@@ -1,5 +1,5 @@
 import { BrowserContext } from "playwright";
-import type { Session } from "../../foxbot/session";
+import type { Session } from "#foxbot/session";
 
 /**
  * Decorator that creates a single Playwright page in the browser context.

--- a/reachly/session/stealth-scripts/session-data.ts
+++ b/reachly/session/stealth-scripts/session-data.ts
@@ -1,8 +1,8 @@
-import type { Device } from "../device";
-import type { Graphics } from "../graphics";
-import type { Host } from "../host";
-import type { Location } from "../location";
-import type { Viewport } from "../viewport";
+import type { Device } from "#reachly/session/device";
+import type { Graphics } from "#reachly/session/graphics";
+import type { Host } from "#reachly/session/host";
+import type { Location } from "#reachly/session/location";
+import type { Viewport } from "#reachly/session/viewport";
 
 export interface SessionData {
   viewport: Viewport;

--- a/reachly/session/stealth-session.ts
+++ b/reachly/session/stealth-session.ts
@@ -1,5 +1,5 @@
 import type { BrowserContext } from "playwright";
-import type { Session } from "../../foxbot/session";
+import type { Session } from "#foxbot/session";
 import type { Device } from "./device";
 import type { Graphics } from "./graphics";
 import type { Host } from "./host";

--- a/reachly/session/viewport.ts
+++ b/reachly/session/viewport.ts
@@ -1,4 +1,4 @@
-import type { Query } from "../../foxbot/core";
+import type { Query } from "#foxbot/core";
 
 /**
  * Viewport and screen dimensions.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,13 @@
     "noImplicitOverride": true,
     "rootDir": ".",
     "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "#foxbot/*": ["foxbot/*"],
+      "#reachly/*": ["reachly/*"],
+      "#examples/*": ["examples/*"],
+      "#tests/*": ["tests/*"]
+    },
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,


### PR DESCRIPTION
## Summary
- add TypeScript path aliases and Node `imports` mappings for root-based imports
- update project files to use `#foxbot` and `#reachly` aliases

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a6a0e3d8832e807b09e94dbe1fb4