### PR TITLE
refactor: use root imports in tests

### DIFF
--- a/tests/e2e/reachly/linkedin-login.e2e.test.ts
+++ b/tests/e2e/reachly/linkedin-login.e2e.test.ts
@@ -1,11 +1,11 @@
 import type { Browser } from "playwright";
 import { describe, expect, it } from "vitest";
-import { Chromium } from "../../../foxbot/browser";
-import { Lambda, Sequence } from "../../../foxbot/control";
-import type { Query } from "../../../foxbot/core";
-import { OptimizedSession, Session, SessionGuard } from "../../../foxbot/session";
-import { Headless, StealthArgs } from "../../../reachly/browser";
-import { LinkedInLogin } from "../../../reachly/linkedin";
+import { Chromium } from "#foxbot/browser";
+import { Lambda, Sequence } from "#foxbot/control";
+import type { Query } from "#foxbot/core";
+import { OptimizedSession, Session, SessionGuard } from "#foxbot/session";
+import { Headless, StealthArgs } from "#reachly/browser";
+import { LinkedInLogin } from "#reachly/linkedin";
 import {
   AuthenticatedSession,
   DefaultSession,
@@ -15,7 +15,7 @@ import {
   JsonLocation,
   JsonViewport,
   StealthSession,
-} from "../../../reachly/session";
+} from "#reachly/session";
 
 /**
  * LinkedIn session decorator that composes stealth, optimization, and authentication capabilities.

--- a/tests/e2e/reachly/playwright/chromium.e2e.test.ts
+++ b/tests/e2e/reachly/playwright/chromium.e2e.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { Chromium } from "../../../../foxbot/browser";
+import { Chromium } from "#foxbot/browser";
 
-import { FakeArgs, FakeHeadless } from "../../../fakes/fake-playwright-queries";
+import { FakeArgs, FakeHeadless } from "#tests/fakes/fake-playwright-queries";
 
 describe("Chromium", () => {
   it("launches chromium browser with headless true", async () => {

--- a/tests/fakes/fake-browser.ts
+++ b/tests/fakes/fake-browser.ts
@@ -1,6 +1,6 @@
 import type { Browser } from "playwright";
 import { chromium } from "playwright";
-import type { Query } from "../../foxbot/core";
+import type { Query } from "#foxbot/core";
 
 /**
  * Fake browser query implementation for session testing purposes.

--- a/tests/fakes/fake-core-session.ts
+++ b/tests/fakes/fake-core-session.ts
@@ -1,5 +1,5 @@
 import type { BrowserContext, Page } from "playwright";
-import type { Session } from "../../foxbot/session";
+import type { Session } from "#foxbot/session";
 
 /**
  * Fake session implementation for foxbot core testing purposes.

--- a/tests/fakes/fake-integration-session.ts
+++ b/tests/fakes/fake-integration-session.ts
@@ -1,6 +1,6 @@
 import type { BrowserContext } from "playwright";
 import { chromium } from "playwright";
-import type { Session } from "../../foxbot/session";
+import type { Session } from "#foxbot/session";
 
 /**
  * Fake session implementation for integration style tests that need a real

--- a/tests/fakes/fake-playwright-queries.ts
+++ b/tests/fakes/fake-playwright-queries.ts
@@ -1,4 +1,4 @@
-import type { Query } from "../../foxbot/core";
+import type { Query } from "#foxbot/core";
 
 /**
  * Fake headless query implementation for testing purposes.

--- a/tests/fakes/fake-session.ts
+++ b/tests/fakes/fake-session.ts
@@ -1,6 +1,6 @@
 import type { BrowserContext } from "playwright";
-import type { Query } from "../../foxbot/core/query";
-import type { Session } from "../../foxbot/session";
+import type { Query } from "#foxbot/core/query";
+import type { Session } from "#foxbot/session";
 import { FakeBrowserContext } from "./fake-browser-context";
 import { FakePage } from "./fake-page";
 

--- a/tests/unit/foxbot/actions/action-decorator.test.ts
+++ b/tests/unit/foxbot/actions/action-decorator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { ActionDecorator } from "../../../../foxbot/control";
-import type { Action } from "../../../../foxbot/core";
+import { ActionDecorator } from "#foxbot/control";
+import type { Action } from "#foxbot/core";
 
 /**
  * Test action implementation that logs execution for verification.

--- a/tests/unit/foxbot/actions/action-primitives.test.ts
+++ b/tests/unit/foxbot/actions/action-primitives.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { Fork, Lambda, NoOp, Sequence } from "../../../../foxbot/control";
-import type { Action } from "../../../../foxbot/core";
-import { BooleanLiteral } from "../../../../foxbot/core";
+import { Fork, Lambda, NoOp, Sequence } from "#foxbot/control";
+import type { Action } from "#foxbot/core";
+import { BooleanLiteral } from "#foxbot/core";
 
 describe("Action primitives", () => {
   it("should execute sequence actions in order", async () => {

--- a/tests/unit/foxbot/actions/actions.test.ts
+++ b/tests/unit/foxbot/actions/actions.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { Fork, NoOp, Sequence, When } from "../../../../foxbot/control";
-import type { Action, Query } from "../../../../foxbot/core";
-import { BooleanLiteral } from "../../../../foxbot/core";
+import { Fork, NoOp, Sequence, When } from "#foxbot/control";
+import type { Action, Query } from "#foxbot/core";
+import { BooleanLiteral } from "#foxbot/core";
 
 // Removed FakeSession usage after OpenSession removal
 

--- a/tests/unit/foxbot/actions/delay.test.ts
+++ b/tests/unit/foxbot/actions/delay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { Delay } from "../../../../foxbot/control/delay";
-import { NumberLiteral } from "../../../../foxbot/value/number_literal";
+import { Delay } from "#foxbot/control/delay";
+import { NumberLiteral } from "#foxbot/value/number_literal";
 
 describe("Delay", () => {
   it("waits for specified milliseconds", async () => {

--- a/tests/unit/foxbot/actions/session-guard.test.ts
+++ b/tests/unit/foxbot/actions/session-guard.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import type { Action } from "../../../../foxbot/core";
-import { SessionGuard } from "../../../../foxbot/session";
-import { FakeSession } from "../../../fakes/fake-session";
+import type { Action } from "#foxbot/core";
+import { SessionGuard } from "#foxbot/session";
+import { FakeSession } from "#tests/fakes/fake-session";
 
 /**
  * Test action implementation that succeeds without side effects.

--- a/tests/unit/foxbot/builders/base64.test.ts
+++ b/tests/unit/foxbot/builders/base64.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { Base64 } from "../../../../foxbot/value/base64";
-import { TextLiteral } from "../../../../foxbot/value/text_literal";
+import { Base64 } from "#foxbot/value/base64";
+import { TextLiteral } from "#foxbot/value/text_literal";
 
 describe("Base64", () => {
   it("decodes valid base64 string correctly", async () => {

--- a/tests/unit/foxbot/builders/contains.test.ts
+++ b/tests/unit/foxbot/builders/contains.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Contains, TextLiteral } from "../../../../foxbot/value";
+import { Contains, TextLiteral } from "#foxbot/value";
 
 describe("Contains", () => {
   it("returns true when haystack contains needle", async () => {

--- a/tests/unit/foxbot/builders/environment-base64.test.ts
+++ b/tests/unit/foxbot/builders/environment-base64.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EnvironmentBase64 } from "../../../../foxbot/value/environment_base64";
+import { EnvironmentBase64 } from "#foxbot/value/environment_base64";
 
 describe("EnvironmentBase64", () => {
   it("returns decoded value when environment variable contains valid base64", async () => {

--- a/tests/unit/foxbot/builders/environment.test.ts
+++ b/tests/unit/foxbot/builders/environment.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Environment } from "../../../../foxbot/value/environment";
+import { Environment } from "#foxbot/value/environment";
 
 describe("Environment", () => {
   it("returns environment variable value when defined", async () => {

--- a/tests/unit/foxbot/builders/number-literal.test.ts
+++ b/tests/unit/foxbot/builders/number-literal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { NumberLiteral } from "../../../../foxbot/value/number_literal";
+import { NumberLiteral } from "#foxbot/value/number_literal";
 
 describe("NumberLiteral", () => {
   it("returns the provided number value", async () => {

--- a/tests/unit/foxbot/builders/random-delay.test.ts
+++ b/tests/unit/foxbot/builders/random-delay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { NumberLiteral } from "../../../../foxbot/value/number_literal";
-import { RandomDelay } from "../../../../foxbot/value/random_delay";
+import { NumberLiteral } from "#foxbot/value/number_literal";
+import { RandomDelay } from "#foxbot/value/random_delay";
 
 describe("RandomDelay", () => {
   it("generates delay within specified bounds", async () => {

--- a/tests/unit/foxbot/core/core.test.ts
+++ b/tests/unit/foxbot/core/core.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { BooleanLiteral, NumberLiteral } from "../../../../foxbot/core";
+import { BooleanLiteral, NumberLiteral } from "#foxbot/core";
 
 describe("core literals", () => {
   it("NumberLiteral returns its number", async () => {

--- a/tests/unit/foxbot/playwright/location-of.test.ts
+++ b/tests/unit/foxbot/playwright/location-of.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Page } from "playwright";
 
-import { LocationOf } from "../../../../foxbot/page";
-import type { Query } from "../../../../foxbot/core";
-import { FakePage } from "../../../fakes/fake-page";
+import { LocationOf } from "#foxbot/page";
+import type { Query } from "#foxbot/core";
+import { FakePage } from "#tests/fakes/fake-page";
 
 describe("LocationOf", () => {
   it("returns current page URL", async () => {

--- a/tests/unit/foxbot/playwright/page-of-from-context.test.ts
+++ b/tests/unit/foxbot/playwright/page-of-from-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { PageOf } from "../../../../foxbot/page/page_of";
-import { FakeCoreSession } from "../../../fakes/fake-core-session";
+import { PageOf } from "#foxbot/page/page_of";
+import { FakeCoreSession } from "#tests/fakes/fake-core-session";
 
 describe("PageOf", () => {
   it("returns page from session host context", async () => {

--- a/tests/unit/foxbot/playwright/page-of.test.ts
+++ b/tests/unit/foxbot/playwright/page-of.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { PageOf } from "../../../../foxbot/page/page_of";
+import { PageOf } from "#foxbot/page/page_of";
 
 // Note: This test is designed to test PageOf construction and interface compliance
 // without requiring complex browser mocking that would violate TypeScript strict rules.

--- a/tests/unit/reachly/playwright/headless.test.ts
+++ b/tests/unit/reachly/playwright/headless.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Headless } from "../../../../reachly/browser/headless";
+import { Headless } from "#reachly/browser/headless";
 
 describe("Headless", () => {
   it("returns true when HEADLESS environment variable is true", async () => {

--- a/tests/unit/reachly/playwright/stealth-args.test.ts
+++ b/tests/unit/reachly/playwright/stealth-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { StealthArgs } from "../../../../reachly/browser/stealth-args";
+import { StealthArgs } from "#reachly/browser/stealth-args";
 
 describe("StealthArgs", () => {
   it("returns default chrome arguments as comma separated string", async () => {

--- a/tests/unit/reachly/sessions/authenticated-session.test.ts
+++ b/tests/unit/reachly/sessions/authenticated-session.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { AuthenticatedSession } from "../../../../reachly/session/authenticated-session";
-import { JsonHost } from "../../../../reachly/session/host";
+import { AuthenticatedSession } from "#reachly/session/authenticated-session";
+import { JsonHost } from "#reachly/session/host";
 
 import { AuthenticatedTestSessionData, FakeIntegrationSession } from "./index";
 

--- a/tests/unit/reachly/sessions/authenticated-test-session-data.ts
+++ b/tests/unit/reachly/sessions/authenticated-test-session-data.ts
@@ -1,4 +1,4 @@
-import { Query } from "../../../../foxbot/core/query";
+import { Query } from "#foxbot/core/query";
 
 /**
  * Authenticated test session data generator implementing Query<string>.

--- a/tests/unit/reachly/sessions/default-session.test.ts
+++ b/tests/unit/reachly/sessions/default-session.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { DefaultSession } from "../../../../reachly/session/default-session";
-import { JsonHost } from "../../../../reachly/session/host";
-import { JsonLocation } from "../../../../reachly/session/location";
-import { JsonViewport } from "../../../../reachly/session/viewport";
+import { DefaultSession } from "#reachly/session/default-session";
+import { JsonHost } from "#reachly/session/host";
+import { JsonLocation } from "#reachly/session/location";
+import { JsonViewport } from "#reachly/session/viewport";
 
 import { FakeBrowser, TestSessionData } from "./index";
 

--- a/tests/unit/reachly/sessions/device.test.ts
+++ b/tests/unit/reachly/sessions/device.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { JsonDevice } from "../../../../reachly/session/device";
-import { TextLiteral } from "../../../../foxbot/value";
+import { JsonDevice } from "#reachly/session/device";
+import { TextLiteral } from "#foxbot/value";
 
 /**
  * Tests for JsonDevice extracting device characteristics.

--- a/tests/unit/reachly/sessions/graphics.test.ts
+++ b/tests/unit/reachly/sessions/graphics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { JsonGraphics } from "../../../../reachly/session/graphics";
-import { TextLiteral } from "../../../../foxbot/value";
+import { JsonGraphics } from "#reachly/session/graphics";
+import { TextLiteral } from "#foxbot/value";
 
 /**
  * Tests for JsonGraphics extracting WebGL characteristics.

--- a/tests/unit/reachly/sessions/host.test.ts
+++ b/tests/unit/reachly/sessions/host.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { JsonHost } from "../../../../reachly/session/host";
-import { TextLiteral } from "../../../../foxbot/value";
+import { JsonHost } from "#reachly/session/host";
+import { TextLiteral } from "#foxbot/value";
 
 /**
  * Tests for JsonHost methods extracting host attributes from JSON query.

--- a/tests/unit/reachly/sessions/index.ts
+++ b/tests/unit/reachly/sessions/index.ts
@@ -1,3 +1,3 @@
-export * from "../../../fakes";
+export * from "#tests/fakes";
 export * from "./authenticated-test-session-data";
 export * from "./test-session-data";

--- a/tests/unit/reachly/sessions/linkedin-session-composition.test.ts
+++ b/tests/unit/reachly/sessions/linkedin-session-composition.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { TextLiteral } from "../../../../foxbot/value";
-import { OptimizedSession } from "../../../../foxbot/session";
+import { TextLiteral } from "#foxbot/value";
+import { OptimizedSession } from "#foxbot/session";
 import {
   AuthenticatedSession,
   DefaultSession,
@@ -11,7 +11,7 @@ import {
   JsonLocation,
   JsonViewport,
   StealthSession,
-} from "../../../../reachly/session";
+} from "#reachly/session";
 
 import { FakeBrowser } from "./index";
 

--- a/tests/unit/reachly/sessions/location.test.ts
+++ b/tests/unit/reachly/sessions/location.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { JsonLocation } from "../../../../reachly/session/location";
-import { TextLiteral } from "../../../../foxbot/value";
+import { JsonLocation } from "#reachly/session/location";
+import { TextLiteral } from "#foxbot/value";
 
 /**
  * Tests for JsonLocation extracting geolocation coordinates.

--- a/tests/unit/reachly/sessions/optimized-session.test.ts
+++ b/tests/unit/reachly/sessions/optimized-session.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { OptimizedSession } from "../../../../foxbot/session";
+import { OptimizedSession } from "#foxbot/session";
 
 import { FakeIntegrationSession } from "./index";
 

--- a/tests/unit/reachly/sessions/single-page.test.ts
+++ b/tests/unit/reachly/sessions/single-page.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { SinglePage } from "../../../../reachly/session/single-page";
+import { SinglePage } from "#reachly/session/single-page";
 
 import { FakeIntegrationSession } from "./index";
 

--- a/tests/unit/reachly/sessions/stealth-scripts.test.ts
+++ b/tests/unit/reachly/sessions/stealth-scripts.test.ts
@@ -12,7 +12,7 @@ import {
   spoofScreenProperties,
   spoofWebGLContext,
   trackMouseMovements,
-} from "../../../../reachly/session/stealth-scripts";
+} from "#reachly/session/stealth-scripts";
 
 describe("Stealth Scripts", () => {
   describe("removeWebDriverProperty", () => {

--- a/tests/unit/reachly/sessions/stealth-session.test.ts
+++ b/tests/unit/reachly/sessions/stealth-session.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import type { Query } from "../../../../foxbot/core/query";
-import { JsonDevice } from "../../../../reachly/session/device";
-import { JsonGraphics } from "../../../../reachly/session/graphics";
-import { JsonHost } from "../../../../reachly/session/host";
-import { JsonLocation } from "../../../../reachly/session/location";
-import { StealthSession } from "../../../../reachly/session/stealth-session";
-import { JsonViewport } from "../../../../reachly/session/viewport";
+import type { Query } from "#foxbot/core/query";
+import { JsonDevice } from "#reachly/session/device";
+import { JsonGraphics } from "#reachly/session/graphics";
+import { JsonHost } from "#reachly/session/host";
+import { JsonLocation } from "#reachly/session/location";
+import { StealthSession } from "#reachly/session/stealth-session";
+import { JsonViewport } from "#reachly/session/viewport";
 
 import { FakeIntegrationSession, TestSessionData } from "./index";
 

--- a/tests/unit/reachly/sessions/test-session-data.ts
+++ b/tests/unit/reachly/sessions/test-session-data.ts
@@ -1,4 +1,4 @@
-import { Query } from "../../../../foxbot/core/query";
+import { Query } from "#foxbot/core/query";
 
 /**
  * Test session data generator implementing Query<string>.

--- a/tests/unit/reachly/sessions/viewport.test.ts
+++ b/tests/unit/reachly/sessions/viewport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { JsonViewport } from "../../../../reachly/session/viewport";
-import { TextLiteral } from "../../../../foxbot/value";
+import { JsonViewport } from "#reachly/session/viewport";
+import { TextLiteral } from "#foxbot/value";
 
 /**
  * Tests for JsonViewport extracting dimensional attributes.

--- a/tests/unit/reachly/workflows/linkedin-login.test.ts
+++ b/tests/unit/reachly/workflows/linkedin-login.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { Base64, Environment } from "../../../../foxbot/value";
+import { Base64, Environment } from "#foxbot/value";
 
 describe("LinkedInLogin", () => {
   it("can be instantiated with valid environment variables", async () => {


### PR DESCRIPTION
## Summary
- refactor tests to use root-based `#` imports

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a9c09348832ea74660ee798b94fb