### PR TITLE
Enforce single assertion per test across suites

### DIFF
--- a/tests/unit/foxbot/actions/action-primitives.test.ts
+++ b/tests/unit/foxbot/actions/action-primitives.test.ts
@@ -5,74 +5,86 @@ import type { Action } from "#foxbot/core";
 import { BooleanLiteral } from "#foxbot/core";
 
 describe("Action primitives", () => {
-  it("should execute sequence actions in order", async () => {
+  it("Sequence executes actions in order", async () => {
+    expect.assertions(1);
     const executionOrder: number[] = [];
-
     class TestAction implements Action {
       constructor(private order: number) {}
       async perform(): Promise<void> {
         executionOrder.push(this.order);
       }
     }
-
     const actions = [new TestAction(1), new TestAction(2), new TestAction(3)];
-
     const sequence = new Sequence(actions);
     await sequence.perform();
-
-    expect(executionOrder).toEqual([1, 2, 3]);
+    expect(executionOrder, "Sequence did not execute actions in order").toEqual([1, 2, 3]);
   });
 
-  it("should handle no-op actions", async () => {
+  it("NoOp performs without throwing", async () => {
+    expect.assertions(1);
     const noOp = new NoOp();
-    await noOp.perform(); // Should not throw
+    await expect(noOp.perform(), "NoOp threw an error").resolves.toBeUndefined();
   });
 
-  it("should execute lambda action", async () => {
+  it("Lambda executes provided action", async () => {
+    expect.assertions(1);
     let executed = false;
     const lambda = new Lambda(async () => {
       executed = true;
     });
-
     await lambda.perform();
-
-    expect(executed).toBe(true);
+    expect(executed, "Lambda action did not execute provided function").toBe(true);
   });
 
-  it("should execute fork actions based on condition", async () => {
+  it("Fork executes then action when condition is true", async () => {
+    expect.assertions(1);
     let thenExecuted = false;
-    let elseExecuted = false;
-
     class ThenAction implements Action {
       async perform(): Promise<void> {
         thenExecuted = true;
       }
     }
+    const fork = new Fork(new BooleanLiteral(true), new ThenAction(), new NoOp());
+    await fork.perform();
+    expect(thenExecuted, "Fork did not execute then action when condition was true").toBe(true);
+  });
 
+  it("Fork skips else action when condition is true", async () => {
+    expect.assertions(1);
+    let elseExecuted = false;
     class ElseAction implements Action {
       async perform(): Promise<void> {
         elseExecuted = true;
       }
     }
+    const fork = new Fork(new BooleanLiteral(true), new NoOp(), new ElseAction());
+    await fork.perform();
+    expect(elseExecuted, "Fork executed else action when condition was true").toBe(false);
+  });
 
-    const thenAction = new ThenAction();
-    const elseAction = new ElseAction();
+  it("Fork executes else action when condition is false", async () => {
+    expect.assertions(1);
+    let elseExecuted = false;
+    class ElseAction implements Action {
+      async perform(): Promise<void> {
+        elseExecuted = true;
+      }
+    }
+    const fork = new Fork(new BooleanLiteral(false), new NoOp(), new ElseAction());
+    await fork.perform();
+    expect(elseExecuted, "Fork did not execute else action when condition was false").toBe(true);
+  });
 
-    // Test true condition
-    const trueFork = new Fork(new BooleanLiteral(true), thenAction, elseAction);
-    await trueFork.perform();
-
-    expect(thenExecuted).toBe(true);
-    expect(elseExecuted).toBe(false);
-
-    // Reset and test false condition
-    thenExecuted = false;
-    elseExecuted = false;
-
-    const falseFork = new Fork(new BooleanLiteral(false), thenAction, elseAction);
-    await falseFork.perform();
-
-    expect(thenExecuted).toBe(false);
-    expect(elseExecuted).toBe(true);
+  it("Fork skips then action when condition is false", async () => {
+    expect.assertions(1);
+    let thenExecuted = false;
+    class ThenAction implements Action {
+      async perform(): Promise<void> {
+        thenExecuted = true;
+      }
+    }
+    const fork = new Fork(new BooleanLiteral(false), new ThenAction(), new NoOp());
+    await fork.perform();
+    expect(thenExecuted, "Fork executed then action when condition was false").toBe(false);
   });
 });

--- a/tests/unit/foxbot/builders/contains.test.ts
+++ b/tests/unit/foxbot/builders/contains.test.ts
@@ -3,12 +3,20 @@ import { Contains, TextLiteral } from "#foxbot/value";
 
 describe("Contains", () => {
   it("returns true when haystack contains needle", async () => {
+    expect.assertions(1);
     const query = new Contains(new TextLiteral("hello world"), new TextLiteral("world"));
-    await expect(query.value()).resolves.toBe(true);
+    await expect(
+      query.value(),
+      "Contains did not evaluate to true when haystack contained needle"
+    ).resolves.toBe(true);
   });
 
   it("returns false when haystack does not contain needle", async () => {
+    expect.assertions(1);
     const query = new Contains(new TextLiteral("hello world"), new TextLiteral("foo"));
-    await expect(query.value()).resolves.toBe(false);
+    await expect(
+      query.value(),
+      "Contains evaluated to true when haystack lacked needle"
+    ).resolves.toBe(false);
   });
 });

--- a/tests/unit/foxbot/builders/random-delay.test.ts
+++ b/tests/unit/foxbot/builders/random-delay.test.ts
@@ -3,35 +3,47 @@ import { NumberLiteral } from "#foxbot/value/number_literal";
 import { RandomDelay } from "#foxbot/value/random_delay";
 
 describe("RandomDelay", () => {
-  it("generates delay within specified bounds", async () => {
-    expect.assertions(2);
+  it("returns delay above minimum bound", async () => {
+    expect.assertions(1);
     const delay = new RandomDelay(new NumberLiteral(5), new NumberLiteral(15));
     const result = await delay.value();
     expect(result, "RandomDelay did not generate delay above minimum bound").toBeGreaterThanOrEqual(
       5
     );
+  });
+
+  it("returns delay below maximum bound", async () => {
+    expect.assertions(1);
+    const delay = new RandomDelay(new NumberLiteral(5), new NumberLiteral(15));
+    const result = await delay.value();
     expect(result, "RandomDelay did not generate delay below maximum bound").toBeLessThan(15);
   });
 
-  it("generates delay with zero minimum", async () => {
-    expect.assertions(2);
+  it("returns delay above zero minimum", async () => {
+    expect.assertions(1);
     const delay = new RandomDelay(new NumberLiteral(0), new NumberLiteral(10));
     const result = await delay.value();
     expect(result, "RandomDelay did not handle zero minimum correctly").toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns delay below maximum with zero minimum", async () => {
+    expect.assertions(1);
+    const delay = new RandomDelay(new NumberLiteral(0), new NumberLiteral(10));
+    const result = await delay.value();
     expect(
       result,
       "RandomDelay did not generate delay below maximum with zero minimum"
     ).toBeLessThan(10);
   });
 
-  it("generates same value when min equals max", async () => {
+  it("returns same value when min equals max", async () => {
     expect.assertions(1);
     const delay = new RandomDelay(new NumberLiteral(42), new NumberLiteral(42));
     const result = await delay.value();
     expect(result, "RandomDelay did not return exact value when min equals max").toBe(42);
   });
 
-  it("generates different values on multiple calls", async () => {
+  it("returns different values on multiple calls", async () => {
     expect.assertions(1);
     const delay = new RandomDelay(new NumberLiteral(1), new NumberLiteral(100));
     const results = await Promise.all([
@@ -48,13 +60,19 @@ describe("RandomDelay", () => {
     ).toBeGreaterThan(1);
   });
 
-  it("handles large number ranges correctly", async () => {
-    expect.assertions(2);
+  it("returns delay above large minimum", async () => {
+    expect.assertions(1);
     const delay = new RandomDelay(new NumberLiteral(999), new NumberLiteral(1000));
     const result = await delay.value();
     expect(result, "RandomDelay did not handle large minimum correctly").toBeGreaterThanOrEqual(
       999
     );
+  });
+
+  it("returns delay below large maximum", async () => {
+    expect.assertions(1);
+    const delay = new RandomDelay(new NumberLiteral(999), new NumberLiteral(1000));
+    const result = await delay.value();
     expect(result, "RandomDelay did not handle large maximum correctly").toBeLessThan(1000);
   });
 });

--- a/tests/unit/foxbot/playwright/location-of.test.ts
+++ b/tests/unit/foxbot/playwright/location-of.test.ts
@@ -7,10 +7,14 @@ import { FakePage } from "#tests/fakes/fake-page";
 
 describe("LocationOf", () => {
   it("returns current page URL", async () => {
+    expect.assertions(1);
     const page = new FakePage();
     await page.goto("https://example.com");
     const pageQuery: Query<Page> = { value: async () => page as unknown as Page };
     const location = new LocationOf(pageQuery);
-    await expect(location.value()).resolves.toBe("https://example.com");
+    await expect(
+      location.value(),
+      "LocationOf did not resolve to the current page URL"
+    ).resolves.toBe("https://example.com");
   });
 });

--- a/tests/unit/reachly/sessions/session-decorator.test.ts
+++ b/tests/unit/reachly/sessions/session-decorator.test.ts
@@ -1,9 +1,10 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 // SessionDecorator removed; keep placeholder so Vitest does not fail on empty file.
 describe.skip("SessionDecorator (removed)", () => {
   it("placeholder", () => {
-    // intentionally left blank
+    expect.assertions(1);
+    expect(true, "placeholder test failed").toBe(true);
   });
 });
 

--- a/tests/unit/reachly/sessions/stealth-scripts.test.ts
+++ b/tests/unit/reachly/sessions/stealth-scripts.test.ts
@@ -16,118 +16,303 @@ import {
 
 describe("Stealth Scripts", () => {
   describe("removeWebDriverProperty", () => {
-    it("should return script that removes webdriver property", () => {
+    it("returns script including webdriver property marker", () => {
+      expect.assertions(1);
       const script = removeWebDriverProperty();
-      expect(script).toContain('"webdriver"');
-      expect(script).toContain("get: () => undefined");
+      expect(script, "removeWebDriverProperty script lacked webdriver marker").toContain(
+        '"webdriver"'
+      );
+    });
+    it("returns script defining webdriver getter to undefined", () => {
+      expect.assertions(1);
+      const script = removeWebDriverProperty();
+      expect(script, "removeWebDriverProperty script did not define getter to undefined").toContain(
+        "get: () => undefined"
+      );
     });
   });
 
   describe("removeCdcProperties", () => {
-    it("should return script that removes Chrome DevTools Console properties", () => {
+    it("returns script removing cdc Array property", () => {
+      expect.assertions(1);
       const script = removeCdcProperties();
-      expect(script).toContain("cdc_adoQpoasnfa76pfcZLmcfl_Array");
-      expect(script).toContain("cdc_adoQpoasnfa76pfcZLmcfl_Promise");
-      expect(script).toContain("cdc_adoQpoasnfa76pfcZLmcfl_Symbol");
+      expect(script, "removeCdcProperties script missed Array property").toContain(
+        "cdc_adoQpoasnfa76pfcZLmcfl_Array"
+      );
+    });
+    it("returns script removing cdc Promise property", () => {
+      expect.assertions(1);
+      const script = removeCdcProperties();
+      expect(script, "removeCdcProperties script missed Promise property").toContain(
+        "cdc_adoQpoasnfa76pfcZLmcfl_Promise"
+      );
+    });
+    it("returns script removing cdc Symbol property", () => {
+      expect.assertions(1);
+      const script = removeCdcProperties();
+      expect(script, "removeCdcProperties script missed Symbol property").toContain(
+        "cdc_adoQpoasnfa76pfcZLmcfl_Symbol"
+      );
     });
   });
 
   describe("spoofChromeRuntime", () => {
-    it("should return script that spoofs Chrome runtime", () => {
+    it("returns script including chrome object", () => {
+      expect.assertions(1);
       const script = spoofChromeRuntime();
-      expect(script).toContain('"chrome"');
-      expect(script).toContain("runtime");
-      expect(script).toContain("onConnect: undefined");
+      expect(script, "spoofChromeRuntime script lacked chrome object").toContain('"chrome"');
+    });
+    it("returns script including runtime property", () => {
+      expect.assertions(1);
+      const script = spoofChromeRuntime();
+      expect(script, "spoofChromeRuntime script lacked runtime property").toContain("runtime");
+    });
+    it("returns script setting onConnect to undefined", () => {
+      expect.assertions(1);
+      const script = spoofChromeRuntime();
+      expect(script, "spoofChromeRuntime script did not set onConnect to undefined").toContain(
+        "onConnect: undefined"
+      );
     });
   });
 
   describe("spoofPermissionsApi", () => {
-    it("should return script that spoofs permissions API", () => {
+    it("returns script spoofing permissions query", () => {
+      expect.assertions(1);
       const script = spoofPermissionsApi();
-      expect(script).toContain("navigator.permissions.query");
-      expect(script).toContain("notifications");
+      expect(script, "spoofPermissionsApi script lacked navigator.permissions.query").toContain(
+        "navigator.permissions.query"
+      );
+    });
+    it("returns script spoofing notifications permission", () => {
+      expect.assertions(1);
+      const script = spoofPermissionsApi();
+      expect(script, "spoofPermissionsApi script lacked notifications spoof").toContain(
+        "notifications"
+      );
     });
   });
 
   describe("spoofNavigatorPlugins", () => {
-    it("should return script that spoofs navigator plugins", () => {
+    it("returns script including plugins property", () => {
+      expect.assertions(1);
       const pluginLength = 1;
       const script = spoofNavigatorPlugins(pluginLength);
-      expect(script).toContain('"plugins"');
-      expect(script).toContain("Chrome PDF Plugin");
-      expect(script).toContain(`length: ${pluginLength}`);
+      expect(script, "spoofNavigatorPlugins script lacked plugins property").toContain('"plugins"');
+    });
+    it("returns script spoofing Chrome PDF Plugin", () => {
+      expect.assertions(1);
+      const pluginLength = 1;
+      const script = spoofNavigatorPlugins(pluginLength);
+      expect(script, "spoofNavigatorPlugins script lacked Chrome PDF Plugin").toContain(
+        "Chrome PDF Plugin"
+      );
+    });
+    it("returns script setting plugin length", () => {
+      expect.assertions(1);
+      const pluginLength = 1;
+      const script = spoofNavigatorPlugins(pluginLength);
+      expect(script, "spoofNavigatorPlugins script did not set plugin length").toContain(
+        `length: ${pluginLength}`
+      );
     });
   });
 
   describe("spoofNavigatorLanguages", () => {
-    it("should return script that spoofs navigator languages", () => {
+    it("returns script including languages property", () => {
+      expect.assertions(1);
       const script = spoofNavigatorLanguages();
-      expect(script).toContain('"languages"');
-      expect(script).toContain("sessionData.host.locale()");
+      expect(script, "spoofNavigatorLanguages script lacked languages property").toContain(
+        '"languages"'
+      );
+    });
+    it("returns script referencing session locale", () => {
+      expect.assertions(1);
+      const script = spoofNavigatorLanguages();
+      expect(script, "spoofNavigatorLanguages script did not reference session locale").toContain(
+        "sessionData.host.locale()"
+      );
     });
   });
 
   describe("spoofDeviceProperties", () => {
-    it("should return script that spoofs device properties", () => {
+    it("returns script including platform property", () => {
+      expect.assertions(1);
       const script = spoofDeviceProperties();
-      expect(script).toContain('"platform"');
-      expect(script).toContain('"deviceMemory"');
-      expect(script).toContain('"hardwareConcurrency"');
+      expect(script, "spoofDeviceProperties script lacked platform property").toContain(
+        '"platform"'
+      );
+    });
+    it("returns script including deviceMemory property", () => {
+      expect.assertions(1);
+      const script = spoofDeviceProperties();
+      expect(script, "spoofDeviceProperties script lacked deviceMemory property").toContain(
+        '"deviceMemory"'
+      );
+    });
+    it("returns script including hardwareConcurrency property", () => {
+      expect.assertions(1);
+      const script = spoofDeviceProperties();
+      expect(script, "spoofDeviceProperties script lacked hardwareConcurrency property").toContain(
+        '"hardwareConcurrency"'
+      );
     });
   });
 
   describe("spoofScreenProperties", () => {
-    it("should return script that spoofs screen properties", () => {
+    it("returns script including width property", () => {
+      expect.assertions(1);
       const defaultTaskbarHeight = 40;
       const script = spoofScreenProperties(defaultTaskbarHeight);
-      expect(script).toContain('"width"');
-      expect(script).toContain('"height"');
-      expect(script).toContain('"availWidth"');
-      expect(script).toContain('"availHeight"');
-      expect(script).toContain(`${defaultTaskbarHeight}`);
+      expect(script, "spoofScreenProperties script lacked width property").toContain('"width"');
+    });
+    it("returns script including height property", () => {
+      expect.assertions(1);
+      const defaultTaskbarHeight = 40;
+      const script = spoofScreenProperties(defaultTaskbarHeight);
+      expect(script, "spoofScreenProperties script lacked height property").toContain('"height"');
+    });
+    it("returns script including availWidth property", () => {
+      expect.assertions(1);
+      const defaultTaskbarHeight = 40;
+      const script = spoofScreenProperties(defaultTaskbarHeight);
+      expect(script, "spoofScreenProperties script lacked availWidth property").toContain(
+        '"availWidth"'
+      );
+    });
+    it("returns script including availHeight property", () => {
+      expect.assertions(1);
+      const defaultTaskbarHeight = 40;
+      const script = spoofScreenProperties(defaultTaskbarHeight);
+      expect(script, "spoofScreenProperties script lacked availHeight property").toContain(
+        '"availHeight"'
+      );
+    });
+    it("returns script using taskbar height", () => {
+      expect.assertions(1);
+      const defaultTaskbarHeight = 40;
+      const script = spoofScreenProperties(defaultTaskbarHeight);
+      expect(script, "spoofScreenProperties script did not use taskbar height").toContain(
+        `${defaultTaskbarHeight}`
+      );
     });
   });
 
   describe("spoofWebGLContext", () => {
-    it("should return script that spoofs WebGL context", () => {
+    it("returns script overriding getContext", () => {
+      expect.assertions(1);
       const script = spoofWebGLContext();
-      expect(script).toContain("HTMLCanvasElement.prototype.getContext");
-      expect(script).toContain("webgl");
-      expect(script).toContain("gl.VENDOR");
-      expect(script).toContain("gl.RENDERER");
+      expect(script, "spoofWebGLContext script did not override getContext").toContain(
+        "HTMLCanvasElement.prototype.getContext"
+      );
+    });
+    it("returns script referencing webgl", () => {
+      expect.assertions(1);
+      const script = spoofWebGLContext();
+      expect(script, "spoofWebGLContext script did not reference webgl").toContain("webgl");
+    });
+    it("returns script spoofing gl.VENDOR", () => {
+      expect.assertions(1);
+      const script = spoofWebGLContext();
+      expect(script, "spoofWebGLContext script did not spoof gl.VENDOR").toContain("gl.VENDOR");
+    });
+    it("returns script spoofing gl.RENDERER", () => {
+      expect.assertions(1);
+      const script = spoofWebGLContext();
+      expect(script, "spoofWebGLContext script did not spoof gl.RENDERER").toContain("gl.RENDERER");
     });
   });
 
   describe("trackMouseMovements", () => {
-    it("should return script that tracks mouse movements", () => {
+    it("returns script including mouseEvents array", () => {
+      expect.assertions(1);
       const maxMouseEvents = 50;
       const script = trackMouseMovements(maxMouseEvents);
-      expect(script).toContain("mouseEvents");
-      expect(script).toContain("mousemove");
-      expect(script).toContain(`${maxMouseEvents}`);
+      expect(script, "trackMouseMovements script lacked mouseEvents").toContain("mouseEvents");
+    });
+    it("returns script registering mousemove", () => {
+      expect.assertions(1);
+      const maxMouseEvents = 50;
+      const script = trackMouseMovements(maxMouseEvents);
+      expect(script, "trackMouseMovements script did not register mousemove").toContain(
+        "mousemove"
+      );
+    });
+    it("returns script using max mouse events", () => {
+      expect.assertions(1);
+      const maxMouseEvents = 50;
+      const script = trackMouseMovements(maxMouseEvents);
+      expect(script, "trackMouseMovements script did not use max mouse events").toContain(
+        `${maxMouseEvents}`
+      );
     });
   });
 
   describe("addBoundingRectJitter", () => {
-    it("should return script that adds jitter to bounding rect", () => {
+    it("returns script overriding getBoundingClientRect", () => {
+      expect.assertions(1);
       const jitterAmount = 0.1;
       const jitterOffset = 0.5;
       const script = addBoundingRectJitter(jitterAmount, jitterOffset);
-      expect(script).toContain("getBoundingClientRect");
-      expect(script).toContain(`${jitterAmount}`);
-      expect(script).toContain(`${jitterOffset}`);
+      expect(
+        script,
+        "addBoundingRectJitter script did not override getBoundingClientRect"
+      ).toContain("getBoundingClientRect");
+    });
+    it("returns script using jitter amount", () => {
+      expect.assertions(1);
+      const jitterAmount = 0.1;
+      const jitterOffset = 0.5;
+      const script = addBoundingRectJitter(jitterAmount, jitterOffset);
+      expect(script, "addBoundingRectJitter script did not use jitter amount").toContain(
+        `${jitterAmount}`
+      );
+    });
+    it("returns script using jitter offset", () => {
+      expect.assertions(1);
+      const jitterAmount = 0.1;
+      const jitterOffset = 0.5;
+      const script = addBoundingRectJitter(jitterAmount, jitterOffset);
+      expect(script, "addBoundingRectJitter script did not use jitter offset").toContain(
+        `${jitterOffset}`
+      );
     });
   });
 
   describe("humanizeFetchTiming", () => {
-    it("should return script that humanizes fetch timing", () => {
+    it("returns script overriding window.fetch", () => {
+      expect.assertions(1);
       const minDelayMs = 5;
       const maxDelayMs = 15;
       const script = humanizeFetchTiming(minDelayMs, maxDelayMs);
-      expect(script).toContain("window.fetch");
-      expect(script).toContain("setTimeout");
-      expect(script).toContain(`${minDelayMs}`);
-      expect(script).toContain(`${maxDelayMs}`);
+      expect(script, "humanizeFetchTiming script did not override window.fetch").toContain(
+        "window.fetch"
+      );
+    });
+    it("returns script using setTimeout", () => {
+      expect.assertions(1);
+      const minDelayMs = 5;
+      const maxDelayMs = 15;
+      const script = humanizeFetchTiming(minDelayMs, maxDelayMs);
+      expect(script, "humanizeFetchTiming script did not use setTimeout").toContain("setTimeout");
+    });
+    it("returns script using minimum delay", () => {
+      expect.assertions(1);
+      const minDelayMs = 5;
+      const maxDelayMs = 15;
+      const script = humanizeFetchTiming(minDelayMs, maxDelayMs);
+      expect(script, "humanizeFetchTiming script did not use minimum delay").toContain(
+        `${minDelayMs}`
+      );
+    });
+    it("returns script using maximum delay", () => {
+      expect.assertions(1);
+      const minDelayMs = 5;
+      const maxDelayMs = 15;
+      const script = humanizeFetchTiming(minDelayMs, maxDelayMs);
+      expect(script, "humanizeFetchTiming script did not use maximum delay").toContain(
+        `${maxDelayMs}`
+      );
     });
   });
 });

--- a/tests/unit/reachly/workflows/linkedin-login.test.ts
+++ b/tests/unit/reachly/workflows/linkedin-login.test.ts
@@ -3,89 +3,89 @@ import { describe, expect, it } from "vitest";
 import { Base64, Environment } from "#foxbot/value";
 
 describe("LinkedInLogin", () => {
-  it("can be instantiated with valid environment variables", async () => {
-    expect.assertions(2);
+  it("decodes LinkedIn username from base64 environment variable", async () => {
+    expect.assertions(1);
+    delete process.env["LINKEDIN_USERNAME"];
     const username = Buffer.from("test@example.com", "utf-8").toString("base64");
-    const password = Buffer.from("testpass123", "utf-8").toString("base64");
     process.env["LINKEDIN_USERNAME"] = username;
-    process.env["LINKEDIN_PASSWORD"] = password;
-
-    // Since LinkedInLogin requires a real Session (and our fake sessions would require
-    // type assertions), we'll test the component parts instead.
-    // Test that environment variables are properly configured
     const usernameEnv = new Environment("LINKEDIN_USERNAME");
-    const passwordEnv = new Environment("LINKEDIN_PASSWORD");
     const usernameBase64 = new Base64(usernameEnv);
-    const passwordBase64 = new Base64(passwordEnv);
-
     const decodedUsername = await usernameBase64.value();
-    const decodedPassword = await passwordBase64.value();
-
-    expect(decodedUsername, "Username was not properly decoded from base64").toBe(
+    expect(decodedUsername, "LinkedIn username was not properly decoded from base64").toBe(
       "test@example.com"
     );
-    expect(decodedPassword, "Password was not properly decoded from base64").toBe("testpass123");
+  });
 
-    delete process.env["LINKEDIN_USERNAME"];
+  it("decodes LinkedIn password from base64 environment variable", async () => {
+    expect.assertions(1);
     delete process.env["LINKEDIN_PASSWORD"];
+    const password = Buffer.from("testpass123", "utf-8").toString("base64");
+    process.env["LINKEDIN_PASSWORD"] = password;
+    const passwordEnv = new Environment("LINKEDIN_PASSWORD");
+    const passwordBase64 = new Base64(passwordEnv);
+    const decodedPassword = await passwordBase64.value();
+    expect(decodedPassword, "LinkedIn password was not properly decoded from base64").toBe(
+      "testpass123"
+    );
   });
 
   it("environment validation throws error when username is missing", async () => {
     expect.assertions(1);
     delete process.env["LINKEDIN_USERNAME"];
+    delete process.env["LINKEDIN_PASSWORD"];
     process.env["LINKEDIN_PASSWORD"] = Buffer.from("testpass", "utf-8").toString("base64");
 
     const usernameEnv = new Environment("LINKEDIN_USERNAME");
-    await expect(usernameEnv.value()).rejects.toThrow(
-      "Environment variable LINKEDIN_USERNAME is not defined"
-    );
-
-    delete process.env["LINKEDIN_PASSWORD"];
+    await expect(
+      usernameEnv.value(),
+      "Environment did not throw for missing LINKEDIN_USERNAME"
+    ).rejects.toThrow("Environment variable LINKEDIN_USERNAME is not defined");
   });
 
   it("environment validation throws error when password is missing", async () => {
     expect.assertions(1);
-    process.env["LINKEDIN_USERNAME"] = Buffer.from("test@example.com", "utf-8").toString("base64");
+    delete process.env["LINKEDIN_USERNAME"];
     delete process.env["LINKEDIN_PASSWORD"];
+    process.env["LINKEDIN_USERNAME"] = Buffer.from("test@example.com", "utf-8").toString("base64");
 
     const passwordEnv = new Environment("LINKEDIN_PASSWORD");
-    await expect(passwordEnv.value()).rejects.toThrow(
-      "Environment variable LINKEDIN_PASSWORD is not defined"
-    );
-
-    delete process.env["LINKEDIN_USERNAME"];
+    await expect(
+      passwordEnv.value(),
+      "Environment did not throw for missing LINKEDIN_PASSWORD"
+    ).rejects.toThrow("Environment variable LINKEDIN_PASSWORD is not defined");
   });
 
   it("base64 validation throws error on invalid input", async () => {
     expect.assertions(1);
+    delete process.env["INVALID_B64"];
     process.env["INVALID_B64"] = "invalid_base64!@#";
 
     const env = new Environment("INVALID_B64");
     const base64 = new Base64(env);
-    await expect(base64.value()).rejects.toThrow("Input contains invalid base64 encoding");
-
-    delete process.env["INVALID_B64"];
+    await expect(base64.value(), "Base64 did not throw for invalid input").rejects.toThrow(
+      "Input contains invalid base64 encoding"
+    );
   });
 
-  it("handles unicode credentials correctly in base64 encoding", async () => {
-    expect.assertions(2);
+  it("decodes unicode username from base64", async () => {
+    expect.assertions(1);
     const unicodeUser = "тест@пример.рф";
-    const unicodePass = "密码测试";
-    process.env["UNICODE_USER"] = Buffer.from(unicodeUser, "utf-8").toString("base64");
-    process.env["UNICODE_PASS"] = Buffer.from(unicodePass, "utf-8").toString("base64");
-
-    const userEnv = new Environment("UNICODE_USER");
-    const passEnv = new Environment("UNICODE_PASS");
-    const userBase64 = new Base64(userEnv);
-    const passBase64 = new Base64(passEnv);
-
-    const decodedUser = await userBase64.value();
-    const decodedPass = await passBase64.value();
-
-    expect(decodedUser, "Unicode username was not properly decoded").toBe(unicodeUser);
-    expect(decodedPass, "Unicode password was not properly decoded").toBe(unicodePass);
-
     delete process.env["UNICODE_USER"];
+    process.env["UNICODE_USER"] = Buffer.from(unicodeUser, "utf-8").toString("base64");
+    const userEnv = new Environment("UNICODE_USER");
+    const userBase64 = new Base64(userEnv);
+    const decodedUser = await userBase64.value();
+    expect(decodedUser, "Unicode username was not properly decoded").toBe(unicodeUser);
+  });
+
+  it("decodes unicode password from base64", async () => {
+    expect.assertions(1);
+    const unicodePass = "密码测试";
     delete process.env["UNICODE_PASS"];
+    process.env["UNICODE_PASS"] = Buffer.from(unicodePass, "utf-8").toString("base64");
+    const passEnv = new Environment("UNICODE_PASS");
+    const passBase64 = new Base64(passEnv);
+    const decodedPass = await passBase64.value();
+    expect(decodedPass, "Unicode password was not properly decoded").toBe(unicodePass);
   });
 });


### PR DESCRIPTION
## Summary
- ensure all tests call `expect.assertions(1)` and verify a single behavior
- split composite checks in actions, LinkedIn login, and stealth script suites into focused cases

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b34af36020832e89afe43ed6008fb2