### PR TITLE
Use test doubles for sessions and add navigate test

### DIFF
--- a/tests/fakes/fake-browser-context.ts
+++ b/tests/fakes/fake-browser-context.ts
@@ -1,25 +1,43 @@
 import { FakePage } from "./fake-page";
 
-/**
- * Fake browser context implementation for testing purposes.
- * Only implements methods actually used in tests to avoid violating type rules.
- */
+export interface FakeCookie {
+  name: string;
+  value: string;
+}
+
 export class FakeBrowserContext {
   private readonly fakePage = new FakePage();
+  private readonly storedCookies: FakeCookie[] = [];
+  constructor(private readonly viewport = { width: 0, height: 0 }) {}
 
   newPage(): Promise<FakePage> {
+    this.fakePage.setViewport(this.viewport);
     return Promise.resolve(this.fakePage);
   }
 
   pages(): FakePage[] {
+    this.fakePage.setViewport(this.viewport);
     return [this.fakePage];
   }
 
-  async close(): Promise<void> {
-    // No-op for test
+  close(): Promise<void> {
+    return Promise.resolve();
   }
 
-  async addCookies(): Promise<void> {
-    // No-op for test
+  addCookies(cookies: FakeCookie[]): Promise<void> {
+    this.storedCookies.push(...cookies);
+    return Promise.resolve();
+  }
+
+  cookies(): Promise<FakeCookie[]> {
+    return Promise.resolve(this.storedCookies);
+  }
+
+  addInitScript(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  route(): Promise<void> {
+    return Promise.resolve();
   }
 }

--- a/tests/fakes/fake-browser.ts
+++ b/tests/fakes/fake-browser.ts
@@ -1,24 +1,10 @@
-import type { Browser } from "playwright";
-import { chromium } from "playwright";
-import type { Query } from "#foxbot/core";
+import { FakeBrowserContext } from "./fake-browser-context";
 
-/**
- * Fake browser query implementation for session testing purposes.
- * Returns a real chromium browser instance for integration testing.
- *
- * @example
- * ```typescript
- * const browserQuery = new FakeBrowser();
- * const browser = await browserQuery.value(); // returns real chromium instance
- * ```
- */
-export class FakeBrowser implements Query<Browser> {
-  /**
-   * Returns a real chromium browser instance.
-   *
-   * @returns Promise resolving to chromium Browser instance
-   */
-  async value(): Promise<Browser> {
-    return await chromium.launch({ headless: true });
+export class FakeBrowser {
+  async value() {
+    return {
+      newContext: async (options?: { viewport?: { width: number; height: number } }) =>
+        new FakeBrowserContext(options?.viewport),
+    };
   }
 }

--- a/tests/fakes/fake-core-session.ts
+++ b/tests/fakes/fake-core-session.ts
@@ -1,6 +1,3 @@
-import type { BrowserContext, Page } from "playwright";
-import type { Session } from "#foxbot/session";
-
 /**
  * Fake session implementation for foxbot core testing purposes.
  * Only implements methods actually used in foxbot core tests to avoid violating type rules.
@@ -11,11 +8,11 @@ import type { Session } from "#foxbot/session";
  * const context = await session.profile();
  * ```
  */
-export class FakeCoreSession implements Session {
-  async profile(): Promise<BrowserContext> {
+export class FakeCoreSession {
+  async profile() {
     return {
-      newPage: async () => ({}) as Page,
-      pages: () => [{} as Page],
-    } as unknown as BrowserContext;
+      newPage: async () => ({}),
+      pages: () => [{}],
+    };
   }
 }

--- a/tests/fakes/fake-page.ts
+++ b/tests/fakes/fake-page.ts
@@ -11,10 +11,10 @@
 export class FakePage {
   private navigatedUrl = "";
   private readonly locators = new Map<string, FakeLocator>();
-
-  goto(url: string): Promise<null> {
+  private viewport = { width: 0, height: 0 };
+  goto(url: string): Promise<void> {
     this.navigatedUrl = url;
-    return Promise.resolve(null);
+    return Promise.resolve();
   }
 
   locator(selector: string): FakeLocator {
@@ -26,6 +26,18 @@ export class FakePage {
 
   url(): string {
     return this.navigatedUrl;
+  }
+
+  setViewport(viewport: { width: number; height: number }): void {
+    this.viewport = viewport;
+  }
+
+  viewportSize(): { width: number; height: number } {
+    return this.viewport;
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/tests/fakes/fake-session.ts
+++ b/tests/fakes/fake-session.ts
@@ -1,6 +1,3 @@
-import type { BrowserContext } from "playwright";
-import type { Query } from "#foxbot/core/query";
-import type { Session } from "#foxbot/session";
 import { FakeBrowserContext } from "./fake-browser-context";
 import { FakePage } from "./fake-page";
 
@@ -14,12 +11,12 @@ import { FakePage } from "./fake-page";
  * const page = await session.page();
  * ```
  */
-export class FakeSession implements Session {
+export class FakeSession {
   private readonly fakePage = new FakePage();
   private readonly fakeBrowserContext = new FakeBrowserContext();
 
-  async profile(): Promise<BrowserContext> {
-    return this.fakeBrowserContext as unknown as BrowserContext;
+  profile() {
+    return Promise.resolve(this.fakeBrowserContext);
   }
 
   page(): Promise<FakePage> {
@@ -37,7 +34,7 @@ export class FakeSession implements Session {
  * const session = await sessionQuery.value();
  * ```
  */
-export function fakeSession(): Query<FakeSession> {
+export function fakeSession() {
   return {
     value: () => Promise.resolve(new FakeSession()),
   };

--- a/tests/unit/foxbot/page/navigate.test.ts
+++ b/tests/unit/foxbot/page/navigate.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+
+import { Navigate } from "#foxbot/page/navigate";
+import { FakePage } from "#tests/fakes";
+
+describe("Navigate", () => {
+  it("navigates page to provided url", async () => {
+    expect.assertions(1);
+    const page = new FakePage();
+    const pageQuery = { value: () => Promise.resolve(page) };
+    const urlQuery = { value: () => Promise.resolve("https://example.com") };
+    const navigate = new Navigate(pageQuery, urlQuery);
+    await navigate.perform();
+    expect(page.url(), "Navigate did not navigate to url").toBe("https://example.com");
+  });
+});

--- a/tests/unit/foxbot/playwright/location-of.test.ts
+++ b/tests/unit/foxbot/playwright/location-of.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Page } from "playwright";
-
 import { LocationOf } from "#foxbot/page";
-import type { Query } from "#foxbot/core";
 import { FakePage } from "#tests/fakes/fake-page";
 
 describe("LocationOf", () => {
@@ -10,7 +7,7 @@ describe("LocationOf", () => {
     expect.assertions(1);
     const page = new FakePage();
     await page.goto("https://example.com");
-    const pageQuery: Query<Page> = { value: async () => page as unknown as Page };
+    const pageQuery = { value: async () => page };
     const location = new LocationOf(pageQuery);
     await expect(
       location.value(),

--- a/tests/unit/reachly/sessions/authenticated-session.test.ts
+++ b/tests/unit/reachly/sessions/authenticated-session.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from "vitest";
 import { AuthenticatedSession } from "#reachly/session/authenticated-session";
 import { JsonHost } from "#reachly/session/host";
 
-import { AuthenticatedTestSessionData, FakeIntegrationSession } from "./index";
+import { AuthenticatedTestSessionData, FakeSession } from "./index";
 
 describe("AuthenticatedSession", () => {
   it("adds LinkedIn cookies to host context", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
     const authenticatedSession = new AuthenticatedSession(
       fakeSession,
       new JsonHost(new AuthenticatedTestSessionData(new Map()))
@@ -27,7 +27,7 @@ describe("AuthenticatedSession", () => {
 
   it("adds additional cookies from session data", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
     const authenticatedSession = new AuthenticatedSession(
       fakeSession,
       new JsonHost(new AuthenticatedTestSessionData(new Map()))
@@ -44,7 +44,7 @@ describe("AuthenticatedSession", () => {
 
   it("sets secure flag on LinkedIn cookies", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
 
     const authenticatedSession = new AuthenticatedSession(
       fakeSession,
@@ -62,7 +62,7 @@ describe("AuthenticatedSession", () => {
 
   it("sets httpOnly flag on LinkedIn cookies", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
 
     const authenticatedSession = new AuthenticatedSession(
       fakeSession,
@@ -80,7 +80,7 @@ describe("AuthenticatedSession", () => {
 
   it("handles session data without additional cookies", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
 
     const authenticatedSession = new AuthenticatedSession(
       fakeSession,

--- a/tests/unit/reachly/sessions/default-session.test.ts
+++ b/tests/unit/reachly/sessions/default-session.test.ts
@@ -70,7 +70,7 @@ describe("DefaultSession", () => {
     const viewport = page.viewportSize();
     await page.close();
     expect(
-      viewport?.width,
+      viewport.width,
       "DefaultSession did not create context with specified viewport width"
     ).toBe(800);
   }, 10000);

--- a/tests/unit/reachly/sessions/optimized-session.test.ts
+++ b/tests/unit/reachly/sessions/optimized-session.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { OptimizedSession } from "#foxbot/session";
 
-import { FakeIntegrationSession } from "./index";
+import { FakeSession } from "./index";
 
 describe("OptimizedSession", () => {
   it("creates host context with route handlers", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
     const optimizedSession = new OptimizedSession(fakeSession);
     const context = await optimizedSession.profile();
     expect(
@@ -18,7 +18,7 @@ describe("OptimizedSession", () => {
 
   it("handles host context creation with unicode paths", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
     const optimizedSession = new OptimizedSession(fakeSession);
     const context = await optimizedSession.profile();
     expect(
@@ -29,7 +29,7 @@ describe("OptimizedSession", () => {
 
   it("opens session without throwing errors", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
     const optimizedSession = new OptimizedSession(fakeSession);
     await expect(optimizedSession.profile()).resolves.toBeDefined();
   });

--- a/tests/unit/reachly/sessions/single-page.test.ts
+++ b/tests/unit/reachly/sessions/single-page.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { SinglePage } from "#reachly/session/single-page";
 
-import { FakeIntegrationSession } from "./index";
+import { FakeSession } from "./index";
 
 describe("SinglePage", () => {
   it("creates a page in host context", async () => {
     expect.assertions(1);
-    const fakeSession = new FakeIntegrationSession();
+    const fakeSession = new FakeSession();
     const singlePageSession = new SinglePage(fakeSession);
     const context = await singlePageSession.profile();
     expect(context.pages().length, "SinglePage did not create a page in host context").toBe(1);

--- a/tests/unit/reachly/sessions/stealth-session.test.ts
+++ b/tests/unit/reachly/sessions/stealth-session.test.ts
@@ -8,7 +8,7 @@ import { JsonLocation } from "#reachly/session/location";
 import { StealthSession } from "#reachly/session/stealth-session";
 import { JsonViewport } from "#reachly/session/viewport";
 
-import { FakeIntegrationSession, TestSessionData } from "./index";
+import { FakeSession, TestSessionData } from "./index";
 
 /**
  * Creates a stealth session for testing purposes.
@@ -18,7 +18,7 @@ import { FakeIntegrationSession, TestSessionData } from "./index";
  * @returns StealthSession configured with fake session and test data
  */
 async function stealthSessionFrom(q: Query<string>): Promise<StealthSession> {
-  const session = new FakeIntegrationSession();
+  const session = new FakeSession();
   return new StealthSession(
     session,
     new JsonViewport(q),


### PR DESCRIPTION
## Summary
- replace integration session tests with lightweight fakes to avoid Playwright dependency
- expand fake browser context utilities and pages
- add unit test for page navigation
- drop type assertions and nullable/unknown types from tests

## Testing
- `npm run test:unit --silent | tail -n 20`
- `npx vitest run tests/unit --coverage --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b350ae0a8c832e93e92ff22fea7208