### PR TITLE
test: add webdriver removal e2e

### DIFF
--- a/tests/e2e/reachly/stealth-scripts/webdriver-removal.e2e.test.ts
+++ b/tests/e2e/reachly/stealth-scripts/webdriver-removal.e2e.test.ts
@@ -1,0 +1,18 @@
+import { chromium } from "playwright";
+import { describe, expect, it } from "vitest";
+
+import { WebDriverRemoval } from "#reachly/session/stealth-scripts";
+
+describe("WebDriverRemoval", () => {
+  it("removes webdriver from the navigator in the browser", async () => {
+    expect.assertions(1);
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    const script = await new WebDriverRemoval().value();
+    await page.addInitScript(script);
+    await page.goto("about:blank");
+    const result = await page.evaluate("navigator.webdriver === undefined");
+    await browser.close();
+    expect(result, "WebDriverRemoval did not remove webdriver").toBe(true);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- add browser e2e test verifying WebDriverRemoval script

## Testing
- `npm test tests/e2e/reachly/stealth-scripts/webdriver-removal.e2e.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5796e9acc832ea5376341a9114236