### PR TITLE
test: add e2e coverage for stealth scripts

### DIFF
--- a/tests/e2e/reachly/session/stealth-scripts/bounding-rect-jitter.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/bounding-rect-jitter.e2e.test.ts
@@ -1,0 +1,29 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { NumberLiteral } from "#foxbot/core";
+import { BoundingRectJitter } from "#reachly/session/stealth-scripts";
+
+it("jitters element bounding rectangle", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.evaluate(() => {
+    const div = document.createElement("div");
+    div.id = "t";
+    div.style.position = "absolute";
+    div.style.left = "0px";
+    div.style.top = "0px";
+    document.body.appendChild(div);
+  });
+  const script = new BoundingRectJitter(new NumberLiteral(1), new NumberLiteral(0.5));
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(() => {
+    Math.random = () => 0;
+    const rect = document.getElementById("t")!.getBoundingClientRect();
+    return rect.x;
+  });
+  await browser.close();
+  expect(value === -0.5, "BoundingRectJitter did not jitter x coordinate").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/bounding-rect-jitter.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/bounding-rect-jitter.e2e.test.ts
@@ -18,9 +18,11 @@ it("jitters element bounding rectangle", async () => {
   });
   const script = new BoundingRectJitter(new NumberLiteral(1), new NumberLiteral(0.5));
   const code = await script.value();
+  await page.evaluate(() => {
+    Math.random = () => 0;
+  });
   await page.evaluate((c: string) => eval(c), code);
   const value = await page.evaluate(() => {
-    Math.random = () => 0;
     const rect = document.getElementById("t")!.getBoundingClientRect();
     return rect.x;
   });

--- a/tests/e2e/reachly/session/stealth-scripts/cdc-removal.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/cdc-removal.e2e.test.ts
@@ -1,0 +1,17 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { CdcRemoval } from "#reachly/session/stealth-scripts";
+
+it("removes cdc markers from window", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.evaluate("window.cdc_adoQpoasnfa76pfcZLmcfl_Array = []");
+  const script = new CdcRemoval();
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate("'cdc_adoQpoasnfa76pfcZLmcfl_Array' in window");
+  await browser.close();
+  expect(value === false, "CdcRemoval did not remove array marker").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/chrome-runtime.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/chrome-runtime.e2e.test.ts
@@ -1,0 +1,16 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { ChromeRuntime } from "#reachly/session/stealth-scripts";
+
+it("defines chrome runtime object", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new ChromeRuntime();
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate("typeof window.chrome.runtime");
+  await browser.close();
+  expect(value === "object", "ChromeRuntime did not define runtime object").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/device-properties.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/device-properties.e2e.test.ts
@@ -1,0 +1,17 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { DeviceProperties } from "#reachly/session/stealth-scripts";
+import { FakeDevice } from "#tests/fakes";
+
+it("spoofs navigator device properties", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new DeviceProperties(new FakeDevice("linux", 2, 4));
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(() => navigator.platform);
+  await browser.close();
+  expect(value === "linux", "DeviceProperties did not spoof platform").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/fetch-timing.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/fetch-timing.e2e.test.ts
@@ -13,7 +13,7 @@ it("delays fetch requests", async () => {
   const value = await page.evaluate(async (c: string) => {
     eval(c);
     const start = performance.now();
-    await fetch("data:");
+    await fetch("data:text/plain,");
     return performance.now() - start;
   }, code);
   await browser.close();

--- a/tests/e2e/reachly/session/stealth-scripts/fetch-timing.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/fetch-timing.e2e.test.ts
@@ -1,0 +1,21 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { NumberLiteral } from "#foxbot/core";
+import { FetchTiming } from "#reachly/session/stealth-scripts";
+
+it("delays fetch requests", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new FetchTiming(new NumberLiteral(10), new NumberLiteral(10));
+  const code = await script.value();
+  const value = await page.evaluate(async (c: string) => {
+    eval(c);
+    const start = performance.now();
+    await fetch("data:");
+    return performance.now() - start;
+  }, code);
+  await browser.close();
+  expect(value >= 10, "FetchTiming did not delay fetch").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/mouse-tracking.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/mouse-tracking.e2e.test.ts
@@ -11,7 +11,7 @@ it("records mouse events", async () => {
   await page.setViewportSize({ width: 100, height: 100 });
   const script = new MouseTracking(new NumberLiteral(10));
   const code = await script.value();
-  await page.evaluate((c: string) => eval(c), code);
+  await page.evaluate(code + " window.mouseEvents = mouseEvents;");
   await page.mouse.move(10, 10);
   const value = await page.evaluate("window.mouseEvents.length");
   await browser.close();

--- a/tests/e2e/reachly/session/stealth-scripts/mouse-tracking.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/mouse-tracking.e2e.test.ts
@@ -15,5 +15,7 @@ it("records mouse events", async () => {
   await page.mouse.move(10, 10);
   const value = await page.evaluate("window.mouseEvents.length");
   await browser.close();
-  expect(value > 0, "MouseTracking did not record mouse events").toBe(true);
+  expect(typeof value === "number" && value > 0, "MouseTracking did not record mouse events").toBe(
+    true
+  );
 });

--- a/tests/e2e/reachly/session/stealth-scripts/mouse-tracking.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/mouse-tracking.e2e.test.ts
@@ -1,0 +1,19 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { NumberLiteral } from "#foxbot/core";
+import { MouseTracking } from "#reachly/session/stealth-scripts";
+
+it("records mouse events", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 100, height: 100 });
+  const script = new MouseTracking(new NumberLiteral(10));
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  await page.mouse.move(10, 10);
+  const value = await page.evaluate("window.mouseEvents.length");
+  await browser.close();
+  expect(value > 0, "MouseTracking did not record mouse events").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/navigator-languages.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/navigator-languages.e2e.test.ts
@@ -1,0 +1,17 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { NavigatorLanguages } from "#reachly/session/stealth-scripts";
+import { FakeHost } from "#tests/fakes";
+
+it("spoofs navigator languages array", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new NavigatorLanguages(new FakeHost("fr-CA"));
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(() => navigator.languages[0]);
+  await browser.close();
+  expect(value === "fr-CA", "NavigatorLanguages did not spoof languages array").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/navigator-plugins.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/navigator-plugins.e2e.test.ts
@@ -1,0 +1,17 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { NumberLiteral } from "#foxbot/core";
+import { NavigatorPlugins } from "#reachly/session/stealth-scripts";
+
+it("spoofs navigator plugins array", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new NavigatorPlugins(new NumberLiteral(1));
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(() => navigator.plugins.length);
+  await browser.close();
+  expect(value === 1, "NavigatorPlugins did not spoof plugins array").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/permissions-api.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/permissions-api.e2e.test.ts
@@ -11,12 +11,14 @@ it("overrides navigator permissions query for notifications", async () => {
   const script = new PermissionsApi();
   const code = await script.value();
   await page.evaluate((c: string) => eval(c), code);
-  const value = await page.evaluate(
-    async () => (await navigator.permissions.query({ name: "notifications" })).state
-  );
+  const value = await page.evaluate(async () => {
+    const query = await navigator.permissions.query({ name: "notifications" });
+    const permission = Notification.permission;
+    return { state: query.state, permission };
+  });
   await browser.close();
   expect(
-    value === Notification.permission,
+    value.state === value.permission,
     "PermissionsApi did not return notification permission"
   ).toBe(true);
 });

--- a/tests/e2e/reachly/session/stealth-scripts/permissions-api.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/permissions-api.e2e.test.ts
@@ -1,0 +1,22 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { PermissionsApi } from "#reachly/session/stealth-scripts";
+
+it("overrides navigator permissions query for notifications", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.evaluate("navigator.permissions.query = () => Promise.resolve({ state: 'denied' })");
+  const script = new PermissionsApi();
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(
+    async () => (await navigator.permissions.query({ name: "notifications" })).state
+  );
+  await browser.close();
+  expect(
+    value === Notification.permission,
+    "PermissionsApi did not return notification permission"
+  ).toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/screen-properties.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/screen-properties.e2e.test.ts
@@ -1,0 +1,18 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { NumberLiteral } from "#foxbot/core";
+import { ScreenProperties } from "#reachly/session/stealth-scripts";
+import { FakeViewport } from "#tests/fakes";
+
+it("spoofs screen dimensions", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new ScreenProperties(new FakeViewport(10, 20, 5), new NumberLiteral(0));
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(() => screen.availHeight);
+  await browser.close();
+  expect(value === 15, "ScreenProperties did not spoof dimensions").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/webdriver-removal.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/webdriver-removal.e2e.test.ts
@@ -1,0 +1,16 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { WebDriverRemoval } from "#reachly/session/stealth-scripts";
+
+it("removes navigator webdriver property", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new WebDriverRemoval();
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(() => navigator.webdriver);
+  await browser.close();
+  expect(value === undefined, "WebDriverRemoval did not remove navigator webdriver").toBe(true);
+});

--- a/tests/e2e/reachly/session/stealth-scripts/webgl-context.e2e.test.ts
+++ b/tests/e2e/reachly/session/stealth-scripts/webgl-context.e2e.test.ts
@@ -1,0 +1,21 @@
+import { chromium } from "playwright";
+import { expect, it } from "vitest";
+
+import { WebGLContext } from "#reachly/session/stealth-scripts";
+import { FakeGraphics } from "#tests/fakes";
+
+it("spoofs webgl vendor string", async () => {
+  expect.assertions(1);
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const script = new WebGLContext(new FakeGraphics("v", "r"));
+  const code = await script.value();
+  await page.evaluate((c: string) => eval(c), code);
+  const value = await page.evaluate(() => {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl");
+    return gl ? gl.getParameter(gl.VENDOR) : "";
+  });
+  await browser.close();
+  expect(value === "v", "WebGLContext did not spoof vendor").toBe(true);
+});

--- a/tests/fakes/fake-device.ts
+++ b/tests/fakes/fake-device.ts
@@ -5,17 +5,17 @@ import type { Device } from "#reachly/session/device";
  */
 export class FakeDevice implements Device {
   constructor(
-    private readonly platform: string,
+    private readonly os: string,
     private readonly memory: number,
-    private readonly concurrency: number
+    private readonly cores: number
   ) {}
   async platform(): Promise<string> {
-    return this.platform;
+    return this.os;
   }
   async deviceMemory(): Promise<number> {
     return this.memory;
   }
   async hardwareConcurrency(): Promise<number> {
-    return this.concurrency;
+    return this.cores;
   }
 }

--- a/tests/fakes/fake-device.ts
+++ b/tests/fakes/fake-device.ts
@@ -1,0 +1,21 @@
+import type { Device } from "#reachly/session/device";
+
+/**
+ * Fake device returning fixed hardware values for tests
+ */
+export class FakeDevice implements Device {
+  constructor(
+    private readonly platform: string,
+    private readonly memory: number,
+    private readonly concurrency: number
+  ) {}
+  async platform(): Promise<string> {
+    return this.platform;
+  }
+  async deviceMemory(): Promise<number> {
+    return this.memory;
+  }
+  async hardwareConcurrency(): Promise<number> {
+    return this.concurrency;
+  }
+}

--- a/tests/fakes/fake-graphics.ts
+++ b/tests/fakes/fake-graphics.ts
@@ -1,0 +1,17 @@
+import type { Graphics } from "#reachly/session/graphics";
+
+/**
+ * Fake graphics returning fixed WebGL info for tests
+ */
+export class FakeGraphics implements Graphics {
+  constructor(
+    private readonly vendor: string,
+    private readonly renderer: string
+  ) {}
+  async webglVendor(): Promise<string> {
+    return this.vendor;
+  }
+  async webglRenderer(): Promise<string> {
+    return this.renderer;
+  }
+}

--- a/tests/fakes/fake-host.ts
+++ b/tests/fakes/fake-host.ts
@@ -1,0 +1,23 @@
+import type { Host } from "#reachly/session/host";
+
+/**
+ * Fake host returning fixed locale for tests
+ */
+export class FakeHost implements Host {
+  constructor(private readonly locale: string) {}
+  async userAgent(): Promise<string> {
+    return "";
+  }
+  async locale(): Promise<string> {
+    return this.locale;
+  }
+  async timezone(): Promise<string> {
+    return "";
+  }
+  async headers(): Promise<Record<string, string>> {
+    return {};
+  }
+  async cookies(): Promise<string> {
+    return "";
+  }
+}

--- a/tests/fakes/fake-host.ts
+++ b/tests/fakes/fake-host.ts
@@ -4,12 +4,12 @@ import type { Host } from "#reachly/session/host";
  * Fake host returning fixed locale for tests
  */
 export class FakeHost implements Host {
-  constructor(private readonly locale: string) {}
+  constructor(private readonly lang: string) {}
   async userAgent(): Promise<string> {
     return "";
   }
   async locale(): Promise<string> {
-    return this.locale;
+    return this.lang;
   }
   async timezone(): Promise<string> {
     return "";

--- a/tests/fakes/fake-viewport.ts
+++ b/tests/fakes/fake-viewport.ts
@@ -1,0 +1,30 @@
+import type { Viewport } from "#reachly/session/viewport";
+
+/**
+ * Fake viewport returning fixed dimensions for tests
+ */
+export class FakeViewport implements Viewport {
+  constructor(
+    private readonly wide: number,
+    private readonly high: number,
+    private readonly bar: number
+  ) {}
+  async width(): Promise<number> {
+    return this.wide;
+  }
+  async height(): Promise<number> {
+    return this.high;
+  }
+  async screenWidth(): Promise<number> {
+    return this.wide;
+  }
+  async screenHeight(): Promise<number> {
+    return this.high;
+  }
+  async devicePixelRatio(): Promise<number> {
+    return 1;
+  }
+  async taskbarHeight(): Promise<number> {
+    return this.bar;
+  }
+}

--- a/tests/fakes/index.ts
+++ b/tests/fakes/index.ts
@@ -5,3 +5,7 @@ export * from "./fake-integration-session";
 export * from "./fake-page";
 export * from "./fake-playwright-queries";
 export * from "./fake-session";
+export * from "./fake-host";
+export * from "./fake-device";
+export * from "./fake-viewport";
+export * from "./fake-graphics";


### PR DESCRIPTION
## Summary
- add e2e tests verifying each stealth script's effect in the browser
- provide fakes for host, device, viewport, and graphics to drive script tests

## Testing
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b57d0bcd80832e825f69e6815c1c7e